### PR TITLE
Add song name to notification

### DIFF
--- a/mopidy_notifier/frontend.py
+++ b/mopidy_notifier/frontend.py
@@ -34,5 +34,5 @@ class NotifierFrontend(pykka.ThreadingActor, CoreListener):
         song = track.name
         artists = ', '.join([a.name for a in track.artists])
         album = track.album.name
-        message = artists + ' - ' + album
+        message = song + '\\n' + artists + ' - ' + album
         self.notify(message)


### PR DESCRIPTION
Hi,
just a small change to add the name of the song to the notification.
works on linux, cant test on osx.
however I don't think that is an issue, only if the newline breaks something...