### PR TITLE
Fix error on notifications for tracks with no album

### DIFF
--- a/mopidy_notifier/frontend.py
+++ b/mopidy_notifier/frontend.py
@@ -33,7 +33,10 @@ class NotifierFrontend(pykka.ThreadingActor, CoreListener):
         track = tl_track.track
         song = track.name
         artists = ', '.join([a.name for a in track.artists])
-        album = track.album.name
+        if track.album.name:
+            album = track.album.name
+        else:
+            album = ''
         if sys.platform.startswith('darwin'):
             subtitle = artists + ' - ' + album
             message = song

--- a/mopidy_notifier/frontend.py
+++ b/mopidy_notifier/frontend.py
@@ -33,7 +33,7 @@ class NotifierFrontend(pykka.ThreadingActor, CoreListener):
         track = tl_track.track
         song = track.name
         artists = ', '.join([a.name for a in track.artists])
-        if track.album.name:
+        if track.album:
             album = track.album.name
         else:
             album = ''


### PR DESCRIPTION
Was getting the following on a track with no album specified:
 

ERROR    Unhandled exception in NotifierFrontend (urn:uuid:50e836d4-867f-4cfb-8e41-58adb5a344dc):
Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/pykka/actor.py", line 200, in _actor_loop
    response = self._handle_receive(message)
  File "/usr/lib/python2.7/dist-packages/pykka/actor.py", line 294, in _handle_receive
    return callee(*message['args'], **message['kwargs'])
  File "/usr/local/lib/python2.7/dist-packages/mopidy/core/listener.py", line 33, in on_event
    getattr(self, event)(**kwargs)
  File "/usr/local/lib/python2.7/dist-packages/mopidy_notifier/frontend.py", line 36, in track_playback_started
    if track.album.name:
AttributeError: 'NoneType' object has no attribute 'name'
