### PR TITLE
Add Album art instead of default notification icon

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -41,11 +41,24 @@ Then install ``mopidy-notifier`` from PyPI::
 Configuration
 =============
 
-No configuration is needed. The extension is enabled by default when it is
-installed. To disable it, add the following to your Mopidy config file::
+The extension is enabled by default when it is installed.
+To disable it, add the following to your Mopidy config file::
 
     [notifier]
     enabled = false
+
+The following configuration values are available:
+
+- ``notifier/enabled``: If the extension should be eneabled or not. Defaults to ``true``.
+- ``notifier/on_start``: Whether a notification should be displayed on mopidy start. Defaults to ``true``.
+- ``notifier/on_start_message``: The notification's message displayed on mopidy start. Defaults to ``Starting...``.
+- ``notifier/on_stop``: Whether a notification should be displayed on mopidy close. Defaults to ``true``.
+- ``notifier/on_stop_message``: The notification's message displayed on mopidy start. Defaults to ``Shutting down...``.
+- ``notifier/message_format``: Format of the notification main message. Defaults to ``{artists} - {album}`` on OSX and ``{song}\\n{artists} - {album}`` on Linux.
+- ``notifier/subtitle_format``: Format of the notification's subtitle. Only available on OSX. Defaults to ``{song}``.
+- ``notifier/album_art``: Whether or not the album art for the current song should be fetched and sent with the notification. Defaults to ``false``.
+- ``notifier/album_art_size``: Size of the album art icon sent to the notification. Defaults to ``64``.
+- ``notifier/default_album_art``: Path to the default image when no album art could be fetched.
 
 
 Project resources

--- a/mopidy_notifier/__init__.py
+++ b/mopidy_notifier/__init__.py
@@ -20,6 +20,12 @@ class Extension(ext.Extension):
 
     def get_config_schema(self):
         schema = super(Extension, self).get_config_schema()
+
+        schema['on_start'] = config.Boolean()
+        schema['on_start_message'] = config.String()
+        schema['on_stop'] = config.Boolean()
+        schema['on_stop_message'] = config.String()
+
         return schema
 
     def setup(self, registry):

--- a/mopidy_notifier/__init__.py
+++ b/mopidy_notifier/__init__.py
@@ -26,6 +26,9 @@ class Extension(ext.Extension):
         schema['on_stop'] = config.Boolean()
         schema['on_stop_message'] = config.String()
 
+        schema['message_format'] = config.String(optional=True)
+        schema['subtitle_format'] = config.String(optional=True)
+
         return schema
 
     def setup(self, registry):

--- a/mopidy_notifier/__init__.py
+++ b/mopidy_notifier/__init__.py
@@ -29,6 +29,10 @@ class Extension(ext.Extension):
         schema['message_format'] = config.String(optional=True)
         schema['subtitle_format'] = config.String(optional=True)
 
+        schema['album_art'] = config.Boolean()
+        schema['album_art_size'] = config.Integer(minimum=8, maximum=512)
+        schema['default_album_art'] = config.String(optional=True)
+
         return schema
 
     def setup(self, registry):

--- a/mopidy_notifier/ext.conf
+++ b/mopidy_notifier/ext.conf
@@ -6,3 +6,6 @@ on_stop = true
 on_stop_message = "Shutting down..."
 message_format =
 subtitle_format =
+album_art = false
+album_art_size = 64
+default_album_art =

--- a/mopidy_notifier/ext.conf
+++ b/mopidy_notifier/ext.conf
@@ -1,2 +1,6 @@
 [notifier]
 enabled = true
+on_start = true
+on_start_message = "Starting..."
+on_stop = true
+on_stop_message = "Shutting down..."

--- a/mopidy_notifier/ext.conf
+++ b/mopidy_notifier/ext.conf
@@ -4,3 +4,5 @@ on_start = true
 on_start_message = "Starting..."
 on_stop = true
 on_stop_message = "Shutting down..."
+message_format =
+subtitle_format =

--- a/mopidy_notifier/frontend.py
+++ b/mopidy_notifier/frontend.py
@@ -10,7 +10,7 @@ from mopidy.core import CoreListener
 class NotifierFrontend(pykka.ThreadingActor, CoreListener):
     def __init__(self, config, core):
         super(NotifierFrontend, self).__init__()
-        self.config = config
+        self.config = config['notifier']
         self.core = core
 
     def notify(self, message, subtitle):
@@ -24,10 +24,12 @@ class NotifierFrontend(pykka.ThreadingActor, CoreListener):
         subprocess.call(call)
 
     def on_start(self):
-        self.notify('Starting...','')
+        if self.config['on_start']:
+            self.notify(self.config['on_start_message'], '')
 
     def on_stop(self):
-        self.notify('Shutting down...','')
+        if self.config['on_stop']:
+            self.notify(self.config['on_stop_message'], '')
 
     def track_playback_started(self, tl_track):
         track = tl_track.track

--- a/mopidy_notifier/frontend.py
+++ b/mopidy_notifier/frontend.py
@@ -1,26 +1,40 @@
 from __future__ import unicode_literals
 
+import re
+import StringIO
+import urllib2
+import os.path
 import subprocess
+import tempfile
 import pykka
 import sys
+from operator import attrgetter
 
+from PIL import Image
 from mopidy.core import CoreListener
-
 
 class NotifierFrontend(pykka.ThreadingActor, CoreListener):
     def __init__(self, config, core):
         super(NotifierFrontend, self).__init__()
         self.config = config['notifier']
         self.core = core
+        if self.config.get('album_art', False):
+            self.dirpath = tempfile.mkdtemp()
 
-    def notify(self, message, subtitle):
+    def notify(self, message, subtitle, album_art=None):
         if sys.platform.startswith('darwin'):
             call = ['terminal-notifier', '-title', 'Mopidy', '-subtitle', subtitle, '-message', message, '-group', 'mopidy']
+            icon_arg = '--contentImage {}'.format(album_art)
         elif sys.platform.startswith('linux'):
-            call = ['notify-send', 'Mopidy', message, '--icon=multimedia-player']
+            call = ['notify-send', 'Mopidy', message]
+            icon_arg = '--icon={}'.format(album_art)
         else:
             # Unsupported system
             raise EnvironmentError((1, "This operating system is not supported."))
+
+        if album_art:
+            call.append(icon_arg)
+
         subprocess.call(call)
 
     def on_start(self):
@@ -31,8 +45,7 @@ class NotifierFrontend(pykka.ThreadingActor, CoreListener):
         if self.config['on_stop']:
             self.notify(self.config['on_stop_message'], '')
 
-    def notification_format(self, tl_track):
-        track = tl_track.track
+    def notification_format(self, track):
         song = track.name
         artists = ', '.join([a.name for a in track.artists])
         album = track.album.name
@@ -54,6 +67,31 @@ class NotifierFrontend(pykka.ThreadingActor, CoreListener):
         subtitle = subtitle_format.format(song=song, artists=artists, album=album)
         return (message, subtitle)
 
+    def fetch_album_art(self, track):
+        album = track.album.name
+        size = (self.config['album_art_size'], self.config['album_art_size'])
+
+        if self.config['album_art']:
+            album_slug = re.sub('[^0-9a-zA-Z]+', '_', album)
+            album_art = '{}/{}.png'.format(self.dirpath, album_slug)
+            if not os.path.isfile(album_art):
+                images = self.core.library.get_images([track.uri]).get()[track.uri]
+                if len(images) > 0:
+                    biggest = max(images, key=attrgetter('width'))
+                    raw = StringIO.StringIO(urllib2.urlopen(biggest.uri).read())
+                    im = Image.open(raw)
+                    im.thumbnail(size, Image.ANTIALIAS)
+                    im.save(album_art, "PNG")
+                else:
+                    album_art = self.config['default_album_art']
+
+        else:
+            album_art = self.config['default_album_art']
+
+        return album_art
+
     def track_playback_started(self, tl_track):
-        message, subtitle = self.notification_format(tl_track)
-        self.notify(message, subtitle)
+        track = tl_track.track
+        message, subtitle = self.notification_format(track)
+        album_art = self.fetch_album_art(track)
+        self.notify(message, subtitle, album_art)

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(
         'setuptools',
         'Mopidy >= 0.18',
         'Pykka >= 1.1',
+        'Pillow >= 4.1.0',
     ],
     entry_points={
         'mopidy.ext': [


### PR DESCRIPTION
I've added some configurations to the notifier. 
Like the possibility to enable/disable and change the notification on startup and shutdown. 
As well giving some flexibility with the notification's message format.

But the biggest change is the ability to get the album art of the playing song and send it to the notifier.
I only tested on Linux so I'm not really sure about OSX.
This work great with `modipy-spotify` I'm not sure how `urllib2.urlopen()` will reacts to local songs.